### PR TITLE
Change logon server IP address

### DIFF
--- a/modules/keeper.js
+++ b/modules/keeper.js
@@ -19,7 +19,7 @@ module.exports = function () {
             "interval": false,
             "memory": [],
              "endpoint": {
-                "ip": "logon.elysium-project.org",
+                "ip": "164.132.233.125", //"logon.elysium-project.org"
                 "port": 3724
             }
         },


### PR DESCRIPTION
I changed the logon server's address to its real IP.

The reason is that recently it's been advised to change the realmlist to the given IP instead of the domain name, given that supposedly there's been some issues with DNS translation. If there were some issues indeed, this will give more consistent results.

The only downside is that if they change the server IP address, we will have to change it too now, but I don't think that's a real issue and it could easily be resolved.