### PR TITLE
Retry on data retrieval failure; 'no data available' view

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,6 +58,23 @@
             outline: none;
         }
 
+        #data-unavailable {
+            background: rgba(0, 0, 0, 0.9);
+            width: 100%;
+            height: 100%;
+            min-width: 100%;
+            min-height: 100%;
+            position: absolute;
+            left: 0;
+            top: 0;
+            padding-top: 30%;
+            text-align: center;
+        }
+        #data-unavailable > span {
+            font-size: 2em;
+            color: white;
+        }
+
         </style>
 
         <script>

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -14,10 +14,27 @@ var es = ElysiumStatus;
 es.fetchData = function() {
 
     $('#loadingImage').fadeIn();
-    $.get('./fetch', function(data){
-        es.newData(data);
-        $('#loadingImage').fadeOut();
-        es.timeout = setTimeout(es.fetchData, 15 * 1000);
+    $.get({
+        url: './fetch',
+
+        success: function(data) {
+            es.newData(data);
+            es.timeout = setTimeout(es.fetchData, 15 * 1000);
+
+            $("#data-unavailable").remove();
+        },
+        error: function() {
+            es.timeout = setTimeout(es.fetchData, 10 * 1000);
+
+            if(!$("#data-unavailable").length) {
+                $("#pageContent").append(
+                    '<div id="data-unavailable"><span>Data currently unavailable.</span><br/><span>Retrying...<span></div>'
+                );
+            }
+        },
+        complete: function() {
+            $('#loadingImage').fadeOut();
+        }
     });
 
     //end es.fetchData


### PR DESCRIPTION
Other than adding what's shown on the picture below, it also fixes a bug where if retrieving **./fetch** failed (for example the website went down or there were internet issues on the client side), the code wouldn't retry anymore and the client would be required to refresh the page in order for status to be fetched again.
![Update](http://image.prntscr.com/image/fd7097095e46480b81b959562d8801d2.png)