### PR TITLE
Change realm names and remove references to Nostalrius

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Elysium-Status
-> See if Elysium / Nostalrius is online or offline. Elysium Status is monitoring the private WoW-server Elysium and its services (website, logon-server and wow-servers). Online monitoring live.
+> See if Elysium is online or offline. Elysium Status is monitoring the private WoW-server Elysium and its services (website, logon-server and wow-servers). Online monitoring live.
 
 Available at [www.elysiumstatus.com](https://www.elysiumstatus.com)
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
     <head>
         <title>Elysium Status</title>
 
-        <meta name="Description" content="See if Elysium / Nostalrius is online or offline. Elysium Status is monitoring the private WoW-server Elysium and its services (website, logon-server and wow-servers). Online monitoring live.">
+        <meta name="Description" content="See if Elysium is online or offline. Elysium Status is monitoring the private WoW-server Elysium and its services (website, logon-server and wow-servers). Online monitoring live.">
         <meta name="Keywords" content="live, elysium, elysium-project, elysium-wow, nostralrius, nostalrius, elysium live, nostalrius live.">
         
         <meta charset="UTF-8">

--- a/modules/keeper.js
+++ b/modules/keeper.js
@@ -54,8 +54,8 @@ module.exports = function () {
                 "port": "8093"
             }
         },
-        "nostalrius_pvp": {
-            "name": "Nostalrius PVP",
+        "anathema_pvp": {
+            "name": "Anathema PVP",
             "status": false,
             "last_updated": null,
             "interval": false,
@@ -65,8 +65,8 @@ module.exports = function () {
                 "port": 8095
             }
         },
-        "nostalrius_pve": {
-            "name": "Nostalrius PVE",
+        "darrowshire_pve": {
+            "name": "Darrowshire PVE",
             "status": false,
             "last_updated": null,
             "interval": false,
@@ -223,8 +223,8 @@ module.exports = function () {
     this.processes['servers'] = function () {
 
         self.processes['scan-server']('elysium_pvp');
-        self.processes['scan-server']('nostalrius_pvp');
-        self.processes['scan-server']('nostalrius_pve');
+        self.processes['scan-server']('anathema_pvp');
+        self.processes['scan-server']('darrowshire_pve');
         self.processes['scan-server']('zethkur_pvp');
 
         //end Keeper.processes['servers']

--- a/static/html/overview.html
+++ b/static/html/overview.html
@@ -85,10 +85,10 @@
         </td>
     </tr>
 
-    <!-- Nostalrius Server -->
-    <tr data-srv="nostalrius_pvp">
+    <!-- Anathema Server -->
+    <tr data-srv="anathema_pvp">
         <td>
-            <h3 class="serverTitle">Nostalrius PvP</h3>
+            <h3 class="serverTitle">Anathema PvP</h3>
             <h4 class="queueText"></h4>
         </td>
         <td>
@@ -104,10 +104,10 @@
         </td>
     </tr>
 
-    <!-- PVE Server -->
-    <tr data-srv="nostalrius_pve">
+    <!-- Darrowshire PVE Server -->
+    <tr data-srv="darrowshire_pve">
         <td>
-            <h3 class="serverTitle">Nostalrius PvE</h3>
+            <h3 class="serverTitle">Darrowshire PvE</h3>
             <h4 class="queueText"></h4>
         </td>
         <td>


### PR DESCRIPTION
Changed realm names to reflect new changes by Elysium and removed all references to Nostalrius, save tags for search engines. Elysium shouldn't be viewed as "Elysium / Nostalrius" anymore after the conflict between the two, the pruning of Nostalrius' data and soon the replacing of the server core.