### PR TITLE
Cleanup markup and CSS

### DIFF
--- a/static/css/site.css
+++ b/static/css/site.css
@@ -1,14 +1,10 @@
-.uppercase::first-letter {
-    text-transform: uppercase;
-}
-
-table h3::first-letter {
+table th::first-letter {
     text-transform: uppercase;
 }
 
 .srvInfrastructure {
-    color: #715284;
-    text-shadow: 1px 1px 1px #000;
+    color: #5d6da9;
+    font-weight: bold;
 }
 
 .srvOnline {
@@ -30,8 +26,9 @@ table h3::first-letter {
 
 .queueText, .populationText {
     color: #6f6f6f;
+    display: block;
 }
-    
+
 .twitter-timeline {
     margin-top: 20px !important;
 }
@@ -83,9 +80,11 @@ table h3::first-letter {
 */
 
 table#services-status-table {
+    background-color: #fff;
     border-left: 1px solid #ddd;
     border-right: 1px solid #ddd;
     border-bottom: 1px solid #ddd;
+    font-size: 12pt;
 }
 
 table#services-status-table tr:first-child th {
@@ -93,7 +92,7 @@ table#services-status-table tr:first-child th {
 }
 
 /*
- --- PAGE: SERVER-DETAILS 
+ --- PAGE: SERVER-DETAILS
 */
 
 div#pageServerDetails {
@@ -106,4 +105,14 @@ div#pageServerDetails {
     border-bottom: 1px solid #ddd;
     border-bottom-left-radius: 5px;
     border-bottom-right-radius: 5px;
+}
+
+
+/*
+ ---  RESPONSIVE STYLES  ---
+ */
+@media only screen and (max-width: 620px) {
+    table#services-status-table {
+        font-size: 10pt;
+    }
 }

--- a/static/html/overview.html
+++ b/static/html/overview.html
@@ -1,129 +1,111 @@
-<table id="services-status-table" class="table" style="background-color: #FFF;">
+<table id="services-status-table" class="table">
     <tr>
-        <th>
-            <h3>#service#</h3>
-        </th>
-        <th>
-            <h3>#status#</h3>
-        </th>
-        <th>
-            <h3>#last_updated#</h3>
-        </th>
+        <th>#service#</th>
+        <th>#status#</th>
+        <th>#last_updated#</th>
     </tr>
 
     <!-- Login Server -->
     <tr data-srv="logon">
-        <td>
-            <h3 class="srvInfrastructure">Elysium Login Server</h3>
+        <td class="srvInfrastructure">
+            Elysium Login Server
         </td>
-        <td>
-            <div class="srvStatus">
-                <h3 class="srvOnline">
-                    <i class="fa fa-check-circle"></i>
-                    Online
-                </h3>
-            </div>
+        <td class="srvOnline">
+            <span class="srvStatus">
+                <i class="fa fa-check-circle"></i>
+                Online
+            </span>
         </td>
-        <td>
-            <h3 class="srvLastUpdated">1 minute ago</h3>
+        <td class="srvLastUpdated">
+            Unknown
         </td>
     </tr>
 
     <!-- Website Server -->
     <tr data-srv="website">
-        <td>
-            <h3 class="srvInfrastructure">Elysium Website</h3>
+        <td class="srvInfrastructure">
+            Elysium Website
         </td>
-        <td>
-            <div class="srvStatus">
-                <h3 class="srvOnline">
-                    <i class="fa fa-check-circle"></i>
-                    Online
-                </h3>
-            </div>
+        <td class="srvOnline">
+            <span class="srvStatus">
+                <i class="fa fa-check-circle"></i>
+                Online
+            </span>
         </td>
-        <td>
-            <h3 class="srvLastUpdated">1 minute ago</h3>
+        <td class="srvLastUpdated">
+            Unknown
         </td>
     </tr>
 
     <!-- Elysium Server -->
     <tr data-srv="elysium_pvp">
         <td>
-            <h3 class="serverTitle">Elysium PvP</h3>
-            <h4 class="queueText"></h4>
-            <h4 class="populationText"></h4>
+            <span class="serverTitle">Elysium PvP</span>
+            <span class="queueText"></span>
+            <span class="populationText"></span>
         </td>
-        <td>
-            <div class="srvStatus">
-                <h3 class="srvOnline">
-                    <i class="fa fa-check-circle"></i>
-                    Online
-                </h3>
-            </div>
+        <td class="srvOnline">
+            <span class="srvStatus">
+                <i class="fa fa-check-circle"></i>
+                Online
+            </span>
         </td>
-        <td>
-            <h3 class="srvLastUpdated">1 minute ago</h3>
+        <td class="srvLastUpdated">
+            Unknown
         </td>
     </tr>
 
-    <!-- Zeth'Kur Server --> 
+    <!-- Zeth'Kur Server -->
     <tr data-srv="zethkur_pvp">
         <td>
-            <h3 class="serverTitle">Zeth'Kur PvP</h3>
-            <h4 class="queueText"></h4>
-            <h4 class="populationText"></h4>
+            <span class="serverTitle">Zeth'Kur PvP</span>
+            <span class="queueText"></span>
+            <span class="populationText"></span>
         </td>
-        <td>
-            <div class="srvStatus">
-                <h3 class="srvOnline">
-                    <i class="fa fa-check-circle"></i>
-                    Online
-                </h3>
-            </div>
+        <td class="srvOnline">
+            <span class="srvStatus">
+                <i class="fa fa-check-circle"></i>
+                Online
+            </span>
         </td>
-        <td>
-            <h3 class="srvLastUpdated">1 minute ago</h3>
+        <td class="srvLastUpdated">
+            Unknown
         </td>
     </tr>
 
     <!-- Anathema Server -->
     <tr data-srv="anathema_pvp">
         <td>
-            <h3 class="serverTitle">Anathema PvP</h3>
-            <h4 class="queueText"></h4>
-            <h4 class="populationText"></h4>
+            <span class="serverTitle">Anathema PvP</span>
+            <span class="queueText"></span>
+            <span class="populationText"></span>
         </td>
-        <td>
-            <div class="srvStatus">
-                <h3 class="srvOnline">
-                    <i class="fa fa-check-circle"></i>
-                    Online
-                </h3>
-            </div>
+        <td class="srvOnline">
+            <span class="srvStatus">
+                <i class="fa fa-check-circle"></i>
+                Online
+            </span>
         </td>
-        <td>
-            <h3 class="srvLastUpdated">1 minute ago</h3>
+        <td class="srvLastUpdated">
+            Unknown
         </td>
     </tr>
 
     <!-- Darrowshire PVE Server -->
     <tr data-srv="darrowshire_pve">
         <td>
-            <h3 class="serverTitle">Darrowshire PvE</h3>
-            <h4 class="queueText"></h4>
-            <h4 class="populationText"></h4>
+            <span class="serverTitle">Darrowshire PvE</span>
+            <span class="queueText"></span>
+            <span class="populationText"></span>
         </td>
-        <td>
-            <div class="srvStatus">
-                <h3 class="srvOnline">
-                    <i class="fa fa-check-circle"></i>
-                    Online
-                </h3>
-            </div>
+        <td class="srvOnline">
+            <span class="srvStatus">
+                <i class="fa fa-check-circle"></i>
+                Online
+            </span>
         </td>
-        <td>
-            <h3 class="srvLastUpdated">1 minute ago</h3>
+        <td class="srvLastUpdated">
+            Unknown
         </td>
     </tr>
 

--- a/static/html/realmdetails.html
+++ b/static/html/realmdetails.html
@@ -1,4 +1,4 @@
-<div id="pageServerDetails" class="row">
+<div id="pageServerDetails">
     <div class="md-12" style="text-align: center;">
         <h2>Coming soon</h2>
     </div>

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -146,7 +146,7 @@ function notificationLine(name, status) {
      }
      return name + statusString + '\n';
 }
-  
+
 function playSound(soundObj) {
     document.getElementById(soundObj).play();
 }
@@ -157,15 +157,15 @@ es.render = function() {
     for (var name in es.data.statuses) {
         var server = es.data.statuses[name];
 
-        //Server status data 
-        $("tr[data-srv='" + name + "']").find('div.srvStatus').html(getStatusText(es.data.statuses[name].status));    
-        $("tr[data-srv='" + name + "']").find('h3.srvLastUpdated').html(getLastUpdated(es.data.statuses[name].last_updated));   
+        //Server status data
+        $("tr[data-srv='" + name + "']").find('span.srvStatus').html(getStatusText(es.data.statuses[name].status));
+        $("tr[data-srv='" + name + "']").find('td.srvLastUpdated').html(getLastUpdated(es.data.statuses[name].last_updated));
 
         //Realm population
         if (server.population != undefined) {
             var popText = (server.population !== false ? lang.tools.uppercase(lang.processKey('players')) + ': ' + server.population : lang.tools.uppercase(lang.processKey('players_unavailable')));
 
-            $("tr[data-srv='" + name + "']").find('h4.populationText').html(popText); 
+            $("tr[data-srv='" + name + "']").find('span.populationText').html(popText);
         }
 
         //-- QUEUE DATA --
@@ -175,10 +175,10 @@ es.render = function() {
 
             if (!aqdataValid) {
                 $("tr[data-srv='" + name + "']").find('.queueText').html('Queues unavailable');
-                continue; 
+                continue;
             }
 
-            //Find AutoQueue for server 
+            //Find AutoQueue for server
             var foundSrv = (es.queueData.servers[name] != undefined ? es.queueData.servers[name] : null);
 
             if (foundSrv == null) continue; //Did not found server.
@@ -193,40 +193,40 @@ es.render = function() {
             //end queueData is set
         }
 
-        //end 
+        //end
     }
 
     //end es.render
 }
-  
 
-//Other 
+
+//Other
 function getStatusText(status) {
 
-    if (status == 'unknown') return '' + 
-        '<h3 class="srvUnknown">' + 
-        '   <i class="fa fa-question-circle-o"></i>' + 
+    if (status == 'unknown') return '' +
+        '<span class="srvUnknown">' +
+        '   <i class="fa fa-question-circle-o"></i>' +
         '    ' + upperFirst(lang.processKey('status_unknown'))+
-        '</h3>';
+        '</span>';
 
-    if (status == 'unstable') return '' + 
-        '<h3 class="srvUnstable">' + 
-        '   <i class="fa fa-exclamation-circle"></i>' + 
-        '    ' + upperFirst(lang.processKey('status_unstable'))+ 
-        '</h3>';
+    if (status == 'unstable') return '' +
+        '<span class="srvUnstable">' +
+        '   <i class="fa fa-exclamation-circle"></i>' +
+        '    ' + upperFirst(lang.processKey('status_unstable'))+
+        '</span>';
 
-    if (status) return '' + 
-        '<h3 class="srvOnline">' + 
-        '   <i class="fa fa-check-circle"></i>' + 
+    if (status) return '' +
+        '<span class="srvOnline">' +
+        '   <i class="fa fa-check-circle"></i>' +
         '    ' + upperFirst(lang.processKey('status_online'))+
-        '</h3>';
+        '</span>';
 
     //Not true
-    return '' + 
-        '<h3 class="srvOffline">' + 
-        '   <i class="fa fa-times-circle"></i>' + 
+    return '' +
+        '<span class="srvOffline">' +
+        '   <i class="fa fa-times-circle"></i>' +
         '    ' + upperFirst(lang.processKey('status_offline'))+
-        '</h3>';
+        '</span>';
 
 }
 
@@ -237,7 +237,7 @@ function getLastUpdated(lastUpdated) {
 
 
     // Do your operations
-    
+
     var endDate   = new Date(es.data.time);
     var seconds = Math.floor((endDate.getTime() - startDate.getTime()) / 1000);
 


### PR DESCRIPTION
Hi there,

I felt like cleaning up a little bit of the HTML and CSS. HTML headers aren't good to use in tables and can often just be styled through some classes on the td elements. I did some polishing and moving stuff to CSS that could simplify things and also reduced the overall text size. Personally, I think it's more readable smaller but you may not -- this was merely my preference. I also added responsiveness for mobile devices so it can be read too. Currently the same h3/h4 sizes would be as large on mobile devices too and difficult to read.

I did some other misc. changes too I suppose.


Table sizes after:
![image](https://cloud.githubusercontent.com/assets/30731/22009961/4f9baeb6-dc54-11e6-945a-d47e77f0d340.png)
